### PR TITLE
[FEATURE] Kafka 기반 실시간 알림 전송 서버 구현

### DIFF
--- a/closet/build.gradle
+++ b/closet/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     runtimeOnly 'org.postgresql:postgresql'
 
@@ -95,6 +96,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.batch:spring-batch-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/closet/src/main/java/com/codeit/closet/common/config/KafkaConsumerConfig.java
+++ b/closet/src/main/java/com/codeit/closet/common/config/KafkaConsumerConfig.java
@@ -1,0 +1,29 @@
+package com.codeit.closet.common.config;
+
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+	@Bean
+	public DefaultErrorHandler kafkaErrorHandler(KafkaTemplate<Object, Object> kafkaTemplate) {
+
+		DeadLetterPublishingRecoverer recoverer =
+			new DeadLetterPublishingRecoverer(
+				kafkaTemplate,
+				(record, ex) ->
+					new TopicPartition(
+						record.topic() + ".DLT",
+						record.partition())
+			);
+		FixedBackOff backOff = new FixedBackOff(0L, 0L);
+
+		return new DefaultErrorHandler(recoverer, backOff);
+	}
+}

--- a/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
+++ b/closet/src/main/java/com/codeit/closet/common/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/api/sse").permitAll()
                         .anyRequest().denyAll()
                 );
         return http.build();

--- a/closet/src/main/java/com/codeit/closet/module/sse/controller/SseController.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/controller/SseController.java
@@ -1,0 +1,138 @@
+package com.codeit.closet.module.sse.controller;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.codeit.closet.module.sse.util.SseEmitterManager;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/sse")
+public class SseController {
+
+	private final SseEmitterManager emitterManager;
+
+	@GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter connect(
+		@RequestParam(name = "lastEventId", required = false) String lastEventId
+	) {
+		UUID receiverId = tryResolveReceiverId();
+
+		SseEmitter emitter;
+
+		if (receiverId == null) {
+			// 연결은 열되 emitter 등록 X
+			log.warn("[SSE] 인증 정보 없음 -> anonymous 연결");
+			emitter = emitterManager.createAnonymousEmitter();
+		} else {
+			emitter = emitterManager.add(receiverId);
+			log.info("[SSE] 인증 사용자 연결, receiverId={}, 현재 연결수={}",
+				receiverId, emitterManager.count(receiverId));
+		}
+
+		try {
+			emitter.send(SseEmitter.event()
+				.id(Instant.now().toString())
+				.name("connect")
+				.data("SSE 연결 성공"));
+		} catch (IOException e) {
+			log.info("[SSE] 초기 이벤트 전송 실패, receiverId={}, reason={}",
+				receiverId, e.getMessage());
+			if (receiverId != null) {
+				emitterManager.remove(receiverId, emitter);
+			}
+
+			emitter.completeWithError(e);
+		}
+
+		if (lastEventId != null && !lastEventId.isBlank()) {
+			log.info("[SSE] 재연결 감지, receiverId={}, lastEventId={}"
+				, receiverId, lastEventId);
+		}
+		return emitter;
+	}
+
+	private UUID tryResolveReceiverId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null
+			|| !authentication.isAuthenticated()
+			|| authentication instanceof AnonymousAuthenticationToken) {
+			return null;
+		}
+
+		Object principal = authentication.getPrincipal();
+
+		// 1) principal이 UUID
+		if (principal instanceof UUID uuid) {
+			return uuid;
+		}
+
+		// 2) principal이 String(UUID)
+		if (principal instanceof String s) {
+			return parseUuidSafely(s);
+		}
+
+		// 3) principal 객체에서 getId()/getUserId()
+		UUID byReflection = tryExtractUuidByReflection(principal);
+		if (byReflection != null) {
+			return byReflection;
+		}
+
+		// 4) authentication.getName()이 UUID
+		String name = authentication.getName();
+		if (name != null && !name.isBlank()) {
+			return parseUuidSafely(name);
+		}
+
+		return null;
+	}
+
+	private UUID tryExtractUuidByReflection(Object principal) {
+		try {
+			Method method = principal.getClass().getMethod("getId");
+			Object value = method.invoke(principal);
+			return parseUuidObject(value);
+		} catch (Exception ignored) {}
+
+		try {
+			Method method = principal.getClass().getMethod("getUserId");
+			Object value = method.invoke(principal);
+			return parseUuidObject(value);
+		} catch (Exception ignored) {}
+
+		return null;
+	}
+
+	private UUID parseUuidObject(Object value) {
+		if (value instanceof UUID uuid) return uuid;
+		if (value instanceof String s) return parseUuidSafely(s);
+		return null;
+	}
+
+	private UUID parseUuidSafely(String value) {
+		try {
+			return UUID.fromString(value);
+		} catch (IllegalArgumentException e) {
+			log.warn("[SSE] UUID 파싱 실패: {}", value);
+			return null;
+		}
+	}
+}

--- a/closet/src/main/java/com/codeit/closet/module/sse/controller/SseController.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/controller/SseController.java
@@ -1,23 +1,20 @@
 package com.codeit.closet.module.sse.controller;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
-import java.time.Instant;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.codeit.closet.module.sse.util.SseEmitterManager;
+import com.codeit.closet.module.sse.util.SseJwtResolver;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,111 +25,34 @@ import lombok.extern.slf4j.Slf4j;
 public class SseController {
 
 	private final SseEmitterManager emitterManager;
+	private final SseJwtResolver jwtResolver;
 
 	@GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-	public SseEmitter connect(
-		@RequestParam(name = "lastEventId", required = false) String lastEventId
-	) {
-		UUID receiverId = tryResolveReceiverId();
-
-		SseEmitter emitter;
+	public SseEmitter connect(HttpServletRequest request) {
+		UUID receiverId = jwtResolver.resolveReceiverId(request);
 
 		if (receiverId == null) {
-			// 연결은 열되 emitter 등록 X
-			log.warn("[SSE] 인증 정보 없음 -> anonymous 연결");
-			emitter = emitterManager.createAnonymousEmitter();
-		} else {
-			emitter = emitterManager.add(receiverId);
-			log.info("[SSE] 인증 사용자 연결, receiverId={}, 현재 연결수={}",
-				receiverId, emitterManager.count(receiverId));
+			log.warn("[SSE] 사용자 식별 실패 (쿠키 없음");
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
 		}
+
+		SseEmitter emitter = emitterManager.add(receiverId);
 
 		try {
 			emitter.send(SseEmitter.event()
-				.id(Instant.now().toString())
 				.name("connect")
 				.data("SSE 연결 성공"));
-		} catch (IOException e) {
-			log.info("[SSE] 초기 이벤트 전송 실패, receiverId={}, reason={}",
-				receiverId, e.getMessage());
-			if (receiverId != null) {
-				emitterManager.remove(receiverId, emitter);
-			}
 
+			log.info("[SSE] 인증 연결 성공, receiverId={}, 현재 연결 수 ={}",
+				receiverId, emitterManager.count(receiverId));
+
+		} catch (IOException e) {
+		    log.error("[SSE] 초기 메시지 전송 실패, receiverId={}, reason={}",
+				receiverId, e.getMessage());
+			emitterManager.remove(receiverId,emitter);
 			emitter.completeWithError(e);
 		}
-
-		if (lastEventId != null && !lastEventId.isBlank()) {
-			log.info("[SSE] 재연결 감지, receiverId={}, lastEventId={}"
-				, receiverId, lastEventId);
-		}
+		log.info("[SSE] 쿠키 인증 연결 성공, receiverId={}", receiverId);
 		return emitter;
-	}
-
-	private UUID tryResolveReceiverId() {
-		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-		if (authentication == null
-			|| !authentication.isAuthenticated()
-			|| authentication instanceof AnonymousAuthenticationToken) {
-			return null;
-		}
-
-		Object principal = authentication.getPrincipal();
-
-		// 1) principal이 UUID
-		if (principal instanceof UUID uuid) {
-			return uuid;
-		}
-
-		// 2) principal이 String(UUID)
-		if (principal instanceof String s) {
-			return parseUuidSafely(s);
-		}
-
-		// 3) principal 객체에서 getId()/getUserId()
-		UUID byReflection = tryExtractUuidByReflection(principal);
-		if (byReflection != null) {
-			return byReflection;
-		}
-
-		// 4) authentication.getName()이 UUID
-		String name = authentication.getName();
-		if (name != null && !name.isBlank()) {
-			return parseUuidSafely(name);
-		}
-
-		return null;
-	}
-
-	private UUID tryExtractUuidByReflection(Object principal) {
-		try {
-			Method method = principal.getClass().getMethod("getId");
-			Object value = method.invoke(principal);
-			return parseUuidObject(value);
-		} catch (Exception ignored) {}
-
-		try {
-			Method method = principal.getClass().getMethod("getUserId");
-			Object value = method.invoke(principal);
-			return parseUuidObject(value);
-		} catch (Exception ignored) {}
-
-		return null;
-	}
-
-	private UUID parseUuidObject(Object value) {
-		if (value instanceof UUID uuid) return uuid;
-		if (value instanceof String s) return parseUuidSafely(s);
-		return null;
-	}
-
-	private UUID parseUuidSafely(String value) {
-		try {
-			return UUID.fromString(value);
-		} catch (IllegalArgumentException e) {
-			log.warn("[SSE] UUID 파싱 실패: {}", value);
-			return null;
-		}
 	}
 }

--- a/closet/src/main/java/com/codeit/closet/module/sse/dto/NotificationCreatedEventDTO.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/dto/NotificationCreatedEventDTO.java
@@ -1,0 +1,15 @@
+package com.codeit.closet.module.sse.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.codeit.closet.common.entity.NotificationLevel;
+
+public record NotificationCreatedEventDTO (
+	UUID id,
+	UUID receiverId,
+	String title,
+	String content,
+	NotificationLevel level,
+	Instant createdAt
+) {}

--- a/closet/src/main/java/com/codeit/closet/module/sse/event/NotificationLevel.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/event/NotificationLevel.java
@@ -1,5 +1,0 @@
-package com.codeit.closet.module.sse.event;
-
-public enum NotificationLevel {
-	INFO, WARNING, ERROR
-}

--- a/closet/src/main/java/com/codeit/closet/module/sse/event/NotificationLevel.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/event/NotificationLevel.java
@@ -1,0 +1,5 @@
+package com.codeit.closet.module.sse.event;
+
+public enum NotificationLevel {
+	INFO, WARNING, ERROR
+}

--- a/closet/src/main/java/com/codeit/closet/module/sse/kafka/NotificationEventConsumer.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/kafka/NotificationEventConsumer.java
@@ -4,19 +4,47 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 import com.codeit.closet.module.sse.dto.NotificationCreatedEventDTO;
+import com.codeit.closet.module.sse.util.SseEmitterManager;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class NotificationEventConsumer {
+
+	private final ObjectMapper objectMapper;
+	private final SseEmitterManager emitterManager;
 
 	@KafkaListener(
 		topics = NotificationTopics.NOTIFICATION_CREATED,
 		groupId = "${spring.kafka.consumer.group-id}"
 	)
-	public void consume(NotificationCreatedEventDTO event) {
-		log.info("[Notification] 알림 수신, receiverId={}, id={}, level={}, title={} ",
-			event.receiverId(), event.id(), event.level(), event.title());
+	public void consume(String payload) {
+		log.info("[Test] raw payload = {}", payload);
+
+		try{
+			NotificationCreatedEventDTO event =
+				objectMapper.readValue(payload,NotificationCreatedEventDTO.class);
+
+			log.info("[SSE] 알림 수신, id={}, receiverId={}, level={}, title={}",
+				event.id(), event.receiverId(), event.level(), event.title());
+
+			emitterManager.send(
+				event.receiverId(),
+				"notification",
+				event
+			);
+		} catch (JsonProcessingException e) {
+			log.warn("[Kafka] JSON 파싱 실패");
+		}
+		catch (Exception e) {
+			log.error("[Kafka] 알 수 없는 오류", e);
+		}
+
+
 	}
 }

--- a/closet/src/main/java/com/codeit/closet/module/sse/kafka/NotificationEventConsumer.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/kafka/NotificationEventConsumer.java
@@ -1,0 +1,22 @@
+package com.codeit.closet.module.sse.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.codeit.closet.module.sse.dto.NotificationCreatedEventDTO;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class NotificationEventConsumer {
+
+	@KafkaListener(
+		topics = NotificationTopics.NOTIFICATION_CREATED,
+		groupId = "${spring.kafka.consumer.group-id}"
+	)
+	public void consume(NotificationCreatedEventDTO event) {
+		log.info("[Notification] 알림 수신, receiverId={}, id={}, level={}, title={} ",
+			event.receiverId(), event.id(), event.level(), event.title());
+	}
+}

--- a/closet/src/main/java/com/codeit/closet/module/sse/kafka/NotificationTopics.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/kafka/NotificationTopics.java
@@ -1,0 +1,7 @@
+package com.codeit.closet.module.sse.kafka;
+
+public final class NotificationTopics {
+	private NotificationTopics() {}
+
+	public static final String NOTIFICATION_CREATED = "notification.created";
+}

--- a/closet/src/main/java/com/codeit/closet/module/sse/util/SseEmitterManager.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/util/SseEmitterManager.java
@@ -1,0 +1,82 @@
+package com.codeit.closet.module.sse.util;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class SseEmitterManager {
+
+	private final ConcurrentHashMap<UUID, Set<SseEmitter>> emitterStore = new ConcurrentHashMap<>();
+
+	private static final long DEFAULT_TIMEOUT_MILLIS = 60L * 60L * 1000L; // 1시간 설정
+
+	public SseEmitter add(UUID receiverId) {
+		SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT_MILLIS);
+
+		Set<SseEmitter> emitters =
+			emitterStore.computeIfAbsent(receiverId, key -> ConcurrentHashMap.newKeySet());
+		emitters.add(emitter);
+
+		emitter.onCompletion(() -> remove(receiverId, emitter));
+		emitter.onTimeout(() -> remove(receiverId, emitter));
+		emitter.onError(ex ->{
+			log.info("[SSE] 연결 오류로 emitter 제거, receiverId={}, 사유={}", receiverId, ex.toString());
+			remove(receiverId, emitter);
+		});
+
+		log.info("[SSE] emitter 등록, receiverId={}, emitter.size={}", receiverId, emitters.size());
+		return emitter;
+	}
+
+	public void remove(UUID receiverId, SseEmitter emitter) {
+		Set<SseEmitter> emitters = emitterStore.get(receiverId);
+		if (emitters == null) {
+			return;
+		}
+
+		boolean removed = emitters.remove(emitter);
+		if (removed) {
+			log.info("[SSE] emitter 제거 receiverId={}, emitters.size={}", receiverId, emitters.size());
+		}
+
+		if (emitters.isEmpty()) {
+			emitterStore.remove(receiverId);
+		}
+	}
+
+	public void send(UUID receiverId, String eventName, Object data) {
+		Set<SseEmitter> emitters = emitterStore.get(receiverId);
+
+		if (emitters == null|| emitters.isEmpty()) {
+			log.info("[SSE] 전송 대상 없음 receiverId={}, eventName={}", receiverId,eventName);
+			return;
+		}
+
+		for (SseEmitter emitter : emitters) {
+			try {
+				emitter.send(SseEmitter.event()
+					.id(Instant.now().toString())
+					.name(eventName)
+					.data(data)
+				);
+			} catch (IOException e) {
+				log.info("[SSE] 전송 실패로 emitter 제거, receiverId={}, 이벤트={}, 사유={}",
+					receiverId, eventName, e.toString());
+				remove(receiverId, emitter);
+			}
+		}
+	}
+	public int count(UUID receiverId) {
+		Set<SseEmitter> emitters = emitterStore.get(receiverId);
+		return emitters == null ? 0 : emitters.size();
+	}
+}

--- a/closet/src/main/java/com/codeit/closet/module/sse/util/SseEmitterManager.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/util/SseEmitterManager.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -15,68 +16,103 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class SseEmitterManager {
 
+	private static final long DEFAULT_TIMEOUT = 60L * 60L * 1000L; // 1 hour
+
 	private final ConcurrentHashMap<UUID, Set<SseEmitter>> emitterStore = new ConcurrentHashMap<>();
 
-	private static final long DEFAULT_TIMEOUT_MILLIS = 60L * 60L * 1000L; // 1시간 설정
-
 	public SseEmitter add(UUID receiverId) {
-		SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT_MILLIS);
+		SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
 
-		Set<SseEmitter> emitters =
-			emitterStore.computeIfAbsent(receiverId, key -> ConcurrentHashMap.newKeySet());
-		emitters.add(emitter);
+		emitterStore
+			.computeIfAbsent(receiverId, id -> new CopyOnWriteArraySet<>())
+			.add(emitter);
 
-		emitter.onCompletion(() -> remove(receiverId, emitter));
-		emitter.onTimeout(() -> remove(receiverId, emitter));
-		emitter.onError(ex ->{
-			log.info("[SSE] 연결 오류로 emitter 제거, receiverId={}, 사유={}", receiverId, ex.toString());
-			remove(receiverId, emitter);
-		});
+		registerLifecycleCallbacks(receiverId, emitter);
 
-		log.info("[SSE] emitter 등록, receiverId={}, emitter.size={}", receiverId, emitters.size());
+		log.debug("[SSE] emitter 등록, receiverId={}, 현재 emitter 수={}",
+			receiverId, emitterStore.get(receiverId).size());
+
 		return emitter;
 	}
 
-	public void remove(UUID receiverId, SseEmitter emitter) {
-		Set<SseEmitter> emitters = emitterStore.get(receiverId);
-		if (emitters == null) {
-			return;
-		}
+	public SseEmitter createAnonymousEmitter() {
+		SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
 
-		boolean removed = emitters.remove(emitter);
-		if (removed) {
-			log.info("[SSE] emitter 제거 receiverId={}, emitters.size={}", receiverId, emitters.size());
-		}
+		emitter.onCompletion(() ->
+			log.debug("[SSE] anonymous emitter completed")
+		);
 
-		if (emitters.isEmpty()) {
-			emitterStore.remove(receiverId);
-		}
+		emitter.onTimeout(() ->
+			log.debug("[SSE] anonymous emitter timeout")
+		);
+
+		emitter.onError(e ->
+			log.debug("[SSE] anonymous emitter error: {}", e.getMessage())
+		);
+
+		return emitter;
 	}
 
 	public void send(UUID receiverId, String eventName, Object data) {
 		Set<SseEmitter> emitters = emitterStore.get(receiverId);
 
-		if (emitters == null|| emitters.isEmpty()) {
-			log.info("[SSE] 전송 대상 없음 receiverId={}, eventName={}", receiverId,eventName);
+		if (emitters == null || emitters.isEmpty()) {
+			log.debug("[SSE] 전송 대상 없음, receiverId={}", receiverId);
 			return;
 		}
 
 		for (SseEmitter emitter : emitters) {
 			try {
 				emitter.send(SseEmitter.event()
-					.id(Instant.now().toString())
 					.name(eventName)
-					.data(data)
-				);
+					.data(data));
 			} catch (IOException e) {
-				log.info("[SSE] 전송 실패로 emitter 제거, receiverId={}, 이벤트={}, 사유={}",
-					receiverId, eventName, e.toString());
+				log.warn("[SSE] 전송 실패, receiverId={}, reason={}",
+					receiverId, e.getMessage());
 				remove(receiverId, emitter);
 			}
 		}
 	}
+
+	public void remove(UUID receiverId, SseEmitter emitter) {
+		Set<SseEmitter> emitters = emitterStore.get(receiverId);
+
+		if (emitters == null) {
+			return;
+		}
+
+		emitters.remove(emitter);
+
+		if (emitters.isEmpty()) {
+			emitterStore.remove(receiverId);
+		}
+
+		log.debug("[SSE] emitter 제거, receiverId={}, 남은 emitter 수={}",
+			receiverId,
+			emitters.size()
+		);
+	}
+
 	public int count(UUID receiverId) {
 		Set<SseEmitter> emitters = emitterStore.get(receiverId);
 		return emitters == null ? 0 : emitters.size();
+	}
+
+	private void registerLifecycleCallbacks(UUID receiverId, SseEmitter emitter) {
+		emitter.onCompletion(() -> {
+			log.debug("[SSE] emitter completion, receiverId={}", receiverId);
+			remove(receiverId, emitter);
+		});
+
+		emitter.onTimeout(() -> {
+			log.debug("[SSE] emitter timeout, receiverId={}", receiverId);
+			remove(receiverId, emitter);
+		});
+
+		emitter.onError(e -> {
+			log.debug("[SSE] emitter error, receiverId={}, reason={}",
+				receiverId, e.getMessage());
+			remove(receiverId, emitter);
+		});
 	}
 }

--- a/closet/src/main/java/com/codeit/closet/module/sse/util/SseEmitterManager.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/util/SseEmitterManager.java
@@ -64,12 +64,14 @@ public class SseEmitterManager {
 		for (SseEmitter emitter : emitters) {
 			try {
 				emitter.send(SseEmitter.event()
+					.id(Instant.now().toString())
 					.name(eventName)
 					.data(data));
 			} catch (IOException e) {
 				log.warn("[SSE] 전송 실패, receiverId={}, reason={}",
 					receiverId, e.getMessage());
 				remove(receiverId, emitter);
+				emitter.completeWithError(e);
 			}
 		}
 	}

--- a/closet/src/main/java/com/codeit/closet/module/sse/util/SseJwtResolver.java
+++ b/closet/src/main/java/com/codeit/closet/module/sse/util/SseJwtResolver.java
@@ -1,0 +1,49 @@
+package com.codeit.closet.module.sse.util;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.codeit.closet.common.security.jwt.JwtObject;
+import com.codeit.closet.common.security.jwt.JwtTokenProvider;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseJwtResolver {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public UUID resolveReceiverId(HttpServletRequest request) {
+		if (request.getCookies() == null) {
+			return null;
+		}
+
+		for (Cookie cookie : request.getCookies()) {
+			if (JwtTokenProvider.REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+				try {
+					String refreshToken = cookie.getValue();
+
+					if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+						return null;
+					}
+
+					JwtObject jwt = jwtTokenProvider.parseRefreshToken(refreshToken);
+					return jwt.userDTO().id();
+
+				} catch (Exception e) {
+				    log.warn("[SSE] RefreshToken 파싱 실패");
+					return null;
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/closet/src/main/resources/application.yml
+++ b/closet/src/main/resources/application.yml
@@ -51,6 +51,10 @@ spring:
         spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
         spring.json.trusted.packages: "*"
 
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
 
 dm:
   api:

--- a/closet/src/main/resources/application.yml
+++ b/closet/src/main/resources/application.yml
@@ -48,8 +48,8 @@ spring:
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
 
       properties:
-        spring.json.trusted.packages: "com.codeit.closet.module.sse.event"
-        spring.json.value.default.type: "com.codeit.closet.module.sse.event.NotificationEventMessage"
+        spring.json.trusted.packages: "com.codeit.closet.module.sse.dto,com.codeit.closet.common.entity"
+        spring.json.value.default.type: "com.codeit.closet.module.sse.dto.NotificationCreatedEventDTO"
         spring.json.use.type.headers: false
 
 

--- a/closet/src/main/resources/application.yml
+++ b/closet/src/main/resources/application.yml
@@ -31,6 +31,28 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
     show-sql: true
+
+  # Kafka
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+
+    consumer:
+      group-id: notification-group
+      auto-offset-reset: latest
+      enable-auto-commit: true
+
+      # key = receiveId.toString()
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+      # value(Json) -> DTO 역직렬화
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+
+      properties:
+        spring.json.trusted.packages: "com.codeit.closet.module.sse.event"
+        spring.json.value.default.type: "com.codeit.closet.module.sse.event.NotificationEventMessage"
+        spring.json.use.type.headers: false
+
+
 dm:
   api:
     base-url: ${DM_API_BASE_URL:http://localhost:8080}

--- a/closet/src/main/resources/application.yml
+++ b/closet/src/main/resources/application.yml
@@ -39,18 +39,17 @@ spring:
     consumer:
       group-id: notification-group
       auto-offset-reset: latest
-      enable-auto-commit: true
 
       # key = receiveId.toString()
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
 
       # value(Json) -> DTO 역직렬화
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
 
       properties:
-        spring.json.trusted.packages: "com.codeit.closet.module.sse.dto,com.codeit.closet.common.entity"
-        spring.json.value.default.type: "com.codeit.closet.module.sse.dto.NotificationCreatedEventDTO"
-        spring.json.use.type.headers: false
+        spring.deserializer.key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: "*"
 
 
 dm:


### PR DESCRIPTION
## 📎 Issue 번호
- closed #5 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 📋 작업 내용 상세
- [x] Kafka 기반 알림 이벤트 수신 구조 구현
- [x] SSE 연결 및 사용자별 emitter 관리 로직 구현
- [x] JWT 기반 사용자 식별 로직 구현 (permetAll()환경)
- [x] Kafka -> SSE 실시간 알림 전달 플로우 검증

## 📄 작업 내용 요약
SSE 서버에서 SSE는 Spring Securty 인증 흐름과 분리된 구조로 동작하며, JWT를 직접 파싱하여 사용자 식별을 수행하고 사용자별로 SSE emitter를 관리함

Kafka notification.created 이벤트를 수신하여 정상 메시지는 SSE를 통해 실시간 전송하게 구현함

역직렬화 실패 문제가 발생하여 서버를 무한대로 점유하는 문제가 발생함 이는 Dead Letter Topic(DLT)으로 분리하여 해결
<img width="1128" height="869" alt="image" src="https://github.com/user-attachments/assets/3dc890d7-a13c-4b3b-a5d0-df591f847e93" />

